### PR TITLE
Persist date filters for commit history views

### DIFF
--- a/src/main/kotlin/com/example/ijcommittracer/actions/ListCommitsAction.kt
+++ b/src/main/kotlin/com/example/ijcommittracer/actions/ListCommitsAction.kt
@@ -4,6 +4,7 @@ import com.example.ijcommittracer.CommitTracerBundle
 import com.example.ijcommittracer.services.NotificationService
 import com.example.ijcommittracer.ui.CommitListDialog
 import com.example.ijcommittracer.ui.SelectRepositoryDialog
+import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -53,14 +54,40 @@ class ListCommitsAction : AnAction(), DumbAware {
         } else {
             repositories.first()
         }
-        
-        // Get default date range (today to 365 days ago)
+
+        // Check if we have persisted date filters
+        val properties = PropertiesComponent.getInstance()
+        val fromDateStr = properties.getValue(CommitListDialog.FROM_DATE_KEY)
+        val toDateStr = properties.getValue(CommitListDialog.TO_DATE_KEY)
+
+        // Default date range (today to 1 month ago)
         val today = Calendar.getInstance()
-        val oneYearAgo = Calendar.getInstance()
-        oneYearAgo.add(Calendar.MONTH, -1)
+        val oneMonthAgo = Calendar.getInstance()
+        oneMonthAgo.add(Calendar.MONTH, -1)
+
+        // Use persisted dates if available, otherwise use defaults
+        val fromDate = if (fromDateStr != null) {
+            try {
+                Date(fromDateStr.toLong())
+            } catch (e: NumberFormatException) {
+                oneMonthAgo.time
+            }
+        } else {
+            oneMonthAgo.time
+        }
+
+        val toDate = if (toDateStr != null) {
+            try {
+                Date(toDateStr.toLong())
+            } catch (e: NumberFormatException) {
+                today.time
+            }
+        } else {
+            today.time
+        }
 
         // Load commits from the selected repository with date range
-        loadCommits(project, selectedRepository, oneYearAgo.time, today.time)
+        loadCommits(project, selectedRepository, fromDate, toDate)
     }
     
     private fun loadCommits(project: Project, repository: GitRepository, fromDate: Date, toDate: Date) {
@@ -219,7 +246,7 @@ class ListCommitsAction : AnAction(), DumbAware {
         // and updating UI visibility - these are lightweight operations
         return ActionUpdateThread.EDT
     }
-    
+
     private fun hasGitRepository(project: Project): Boolean {
         val vcsManager = ProjectLevelVcsManager.getInstance(project)
         return vcsManager.allVcsRoots.isNotEmpty() && 
@@ -241,7 +268,7 @@ class ListCommitsAction : AnAction(), DumbAware {
         if (path.endsWith(".iml") || path.endsWith(".bazel")) {
             return false
         }
-        
+
         return path.contains("/test/") || 
                path.contains("/tests/") || 
                path.contains("Test.") || 

--- a/src/main/kotlin/com/example/ijcommittracer/ui/CommitListDialog.kt
+++ b/src/main/kotlin/com/example/ijcommittracer/ui/CommitListDialog.kt
@@ -9,6 +9,7 @@ import com.example.ijcommittracer.ui.components.CommitsPanel
 import com.example.ijcommittracer.ui.components.DateFilterPanel
 import com.example.ijcommittracer.ui.models.AuthorTableModel
 import com.example.ijcommittracer.ui.models.CommitTableModel
+import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
@@ -54,6 +55,12 @@ class CommitListDialog(
     // Pattern for YouTrack ticket references
     // Matches project code in capital letters, followed by a hyphen, followed by numbers (e.g. IDEA-12345)
     private val youtrackTicketPattern = Pattern.compile("([A-Z]+-\\d+)")
+
+    companion object {
+        // Property keys for persisting date filters
+        const val FROM_DATE_KEY = "com.example.ijcommittracer.fromDate"
+        const val TO_DATE_KEY = "com.example.ijcommittracer.toDate"
+    }
 
     init {
         title = CommitTracerBundle.message("dialog.commits.title")
@@ -109,7 +116,12 @@ class CommitListDialog(
         // Update date range and refresh commits
         fromDate = newFromDate
         toDate = newToDate
-        
+
+        // Save the date filter values to persist them between dialog invocations
+        val properties = PropertiesComponent.getInstance()
+        properties.setValue(FROM_DATE_KEY, fromDate.time.toString())
+        properties.setValue(TO_DATE_KEY, toDate.time.toString())
+
         refreshCommitsWithDateFilter()
     }
     


### PR DESCRIPTION
Added functionality to persist and restore date filters in the commit history dialog using `PropertiesComponent`. This ensures date range settings are retained between dialog invocations, improving user experience and workflow continuity.

Generated by Junie.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/2a3cffc6-b88f-4445-be0a-2829598e123b" />
