### PR TITLE
Remove marketplace reference from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ An IntelliJ IDEA plugin that analyzes Git commit history and integrates with You
 
 ## Installation
 
-1. Download the plugin from the JetBrains Marketplace
-2. Install via IntelliJ IDEA: Settings/Preferences → Plugins → Install from disk
-3. Restart IntelliJ IDEA
+1. Install via IntelliJ IDEA: Settings/Preferences → Plugins → Install from disk
+2. Restart IntelliJ IDEA
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Updated README.md to remove reference to JetBrains Marketplace in the installation instructions
- Simplified installation steps as the plugin isn't published on the marketplace

## Test plan
- Verify README.md displays correct installation instructions without marketplace references

🤖 Generated with [Claude Code](https://claude.ai/code)